### PR TITLE
SHA now works

### DIFF
--- a/supergenpass.sh
+++ b/supergenpass.sh
@@ -18,7 +18,7 @@ hash=$master_password:$domain
 i=0
 while true
 do
-	hash=$(echo -n "$hash" | openssl "$hashing_algorithm" -binary | base64 | tr +/= 98A)
+	hash=$(echo -n "$hash" | openssl "$hashing_algorithm" -binary | base64 -w0 | tr +/= 98A)
 	i=$(($i + 1))
 	if [ $i -lt 10 ]
 	then


### PR DESCRIPTION
It looks like base64 breaks at 78 column which makes SHA512 not work on my system. This fixes it.