### PR TITLE
Validation fixed for non-C locales

### DIFF
--- a/supergenpass.sh
+++ b/supergenpass.sh
@@ -24,7 +24,7 @@ do
 	then
 		continue
 	fi
-	valid=$(echo "${hash:0:$length}" | egrep '^[a-z]' | egrep '.[A-Z]' | egrep '.[0-9]' )
+	valid=$(echo "${hash:0:$length}" | egrep '^[[:lower:]]' | egrep '.[[:upper:]]' | egrep '.[[:digit:]]')
 	if [ "$valid" != "" ]
 	then
 		break


### PR DESCRIPTION
For some locales (like Czech in my case) the `[a-z]` actually means `[A-Za-z]`. I was surprised too, but this is in the egrep man page. This fixes it.