### PR TITLE
Eliminate dependency on gnu coreutils base64

### DIFF
--- a/supergenpass.sh
+++ b/supergenpass.sh
@@ -18,7 +18,7 @@ hash=$master_password:$domain
 i=0
 while true
 do
-	hash=$(echo -n "$hash" | openssl "$hashing_algorithm" -binary | base64 -w0 | tr +/= 98A)
+	hash=$(echo -n "$hash" | openssl "$hashing_algorithm" -binary | base64 | tr -d '\n' | tr +/= 98A)
 	i=$(($i + 1))
 	if [ $i -lt 10 ]
 	then


### PR DESCRIPTION
Commit 8f16aa2d3304482f8a6167e40e55484292a29810 introduced a dependency on gnu coreutils version of base64. 
This broke on MacOS and likely other bsd distros that don't use gnu base utils.

This change uses tr remove the newline introduced by base64 instead of relying on options unique to gnu's base64 implementation